### PR TITLE
Plugin: find dependents of a list of packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ npmconf.load({}, function (err, conf) {
     require('npmd-install')(config),
     require('./plugins/versions'),
     require('./plugins/packages'),
+    require('./plugins/dependents'),
     {commands: function (db) {
       db.commands.push(function (db, config, cb) {
           fs.createReadStream(__dirname + '/README.md')

--- a/plugins/dependents.js
+++ b/plugins/dependents.js
@@ -1,0 +1,31 @@
+exports.cli = function (db) {
+    db.commands.push(function (db, config, cb) {
+        var args = config._.slice();
+        if (args.shift() != "dependents") return;
+
+        var modulenames = args;
+
+        db.sublevel('ver').createReadStream({
+        }).on('data', function (data) {
+            var pkg = data.value;
+
+            if (pkg.hasOwnProperty("dependencies") && pkg.dependencies != null) {
+                var all = true;
+
+                modulenames.forEach(function (modulename) {
+                    if (!pkg.dependencies.hasOwnProperty(modulename))
+                        all = false;
+                });
+
+                // TODO: pipe this off into some stream other than process.stdout
+                if (all === true)
+                    if (config.verbose)
+                        console.log(pkg.name + "@" + pkg.version)
+                    else
+                        console.log(pkg.name);
+            }
+        }).on('end', cb);
+
+        return true;
+    });
+};


### PR DESCRIPTION
Usage:

npmd dependents concat-stream through

TODO:
- search for packages only depending on a certain version of a package
- use actual streaming conventions instead of console.log
